### PR TITLE
Ipc changes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -184,7 +184,6 @@ function setupSdkUtility(): void {
         hideAllOverlays()
       }
     } else if (data.name === 'session-info-update') {
-      // If telemetryWindow exists, send directly
       if (telemetryWindow && !telemetryWindow.isDestroyed()) {
         telemetryWindow.webContents.send('session-info-update', data.value)
       }

--- a/src/main/utilities/sdkUtility.ts
+++ b/src/main/utilities/sdkUtility.ts
@@ -63,7 +63,7 @@ iracing.on('Telemetry', (telemetry) => {
   mainPort.postMessage(telemetryValues)
 })
 
-iracing.once('SessionInfo', function (evt) {
+iracing.on('SessionInfo', function (evt) {
   driverCarIdx = evt.data.DriverInfo.DriverCarIdx
   driverCarName = evt.data.DriverInfo.Drivers[driverCarIdx].CarScreenName
 

--- a/src/main/utilities/sdkUtility.ts
+++ b/src/main/utilities/sdkUtility.ts
@@ -70,12 +70,6 @@ iracing.on('SessionInfo', function (evt) {
   let currentSessionNum = evt.data.SessionInfo.CurrentSessionNum
   let session = evt.data.SessionInfo.Sessions[currentSessionNum]
 
-  // if session type has changed fire update event
-  if (session.SessionType !== currentSessionType) {
-    currentSessionType = session.SessionType
-    mainPort.postMessage({ name: 'session-type-update', value: currentSessionType })
-  }
-
   const sessionInfo: SessionInfo = {
     sessionType: session.SessionType,
     driverCarName: driverCarName

--- a/src/preload/twoWayIPC.ts
+++ b/src/preload/twoWayIPC.ts
@@ -10,7 +10,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('electronAPI', {
       sendMessage: (msg: BasicMessage) => ipcRenderer.send('message', msg),
       onMessage: (callback: (msg: BasicMessage) => void) =>
-        ipcRenderer.on('message', (event, msg) => callback(msg))
+        ipcRenderer.on('message', (_event, msg) => callback(msg))
     })
   } catch (error) {
     console.error(error)

--- a/src/renderer/src/components/mainMenu/GeneralSettings.vue
+++ b/src/renderer/src/components/mainMenu/GeneralSettings.vue
@@ -12,7 +12,7 @@ const isDraggable = ref<boolean>(false)
 
 function toggleDraggable() {
   isDraggable.value = !isDraggable.value
-  window.electronAPI.sendMessage({ name: 'windows-draggable', value: isDraggable.value })
+  window.electronAPIIPC.sendMessage({ name: 'windows-draggable', value: isDraggable.value })
 }
 
 onMounted(() => {})

--- a/src/renderer/src/vue-apps/TelemetryApp.vue
+++ b/src/renderer/src/vue-apps/TelemetryApp.vue
@@ -225,7 +225,7 @@ const sessionTypeIsRace = computed(() => sessionType.value.toLowerCase() === 'ra
 onMounted(() => {
   let intervalId: number
   // process the incoming telemetry data being sent from the main process
-  window.electronAPI.onSdkTelemetryUpdate((telemetry: Telemetry) => {
+  window.electronAPITelemetry.onSdkTelemetryUpdate((telemetry: Telemetry) => {
     // add the new telemetry data to the pedalInputs array, and remove the oldest data
     pedalInputs.value.push({
       brakeInputValue: telemetry.BrakeInputValue,
@@ -268,13 +268,13 @@ onMounted(() => {
     P2PCount.value = telemetry.P2PCount
   })
 
-  window.electronAPI.sessionInfoUpdate((sessionInfo: SessionInfo) => {
+  window.electronAPITelemetry.sessionInfoUpdate((sessionInfo: SessionInfo) => {
     sessionType.value = sessionInfo.sessionType
 
     driverCarName.value = sessionInfo.driverCarName
   })
 
-  window.electronAPI.windowsDraggable((value: boolean) => {
+  window.electronAPITelemetry.windowsDraggable((value: boolean) => {
     isDraggable.value = value
   })
 })

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,16 +1,22 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 
-export type ExtendedElectronAPI = ElectronAPI & {
+export type ElectronAPIIPC = ElectronAPI & {
+  sendMessage: (msg: BasicMessage) => void
+  onMessage: (callback: (msg: BasicMessage) => void) => void
+}
+
+export type ElectronAPITelemetry = ElectronAPI & {
   onSdkTelemetryUpdate: (callback: (lapTime: Telemetry) => void) => void
   sessionInfoUpdate: (callback: (sessionInfo: SessionInfo) => void) => void
   closeProgram: () => void
-  sendMessage: (msg: basicMessage) => void
+  sendMessage: (msg: BasicMessage) => void
   windowsDraggable: (callback: (value: boolean) => void) => void
 }
 
 declare global {
   interface Window {
-    electronAPI: ExtendedElectronAPI
+    electronAPIIPC: ElectronAPIIPC
+    electronAPITelemetry: ElectronAPITelemetry
     api: unknown
   }
 


### PR DESCRIPTION
replaced the single window.ExtendedElectronAPI interface with multiple interfaces, each corresponding to a given preload script. each renderer should now only use the api interface that exposes the features in the matching preload script

removed some unused events and converted sessionInfo event handler from 'once' to 'on'. this was a mistake left over from development